### PR TITLE
Remove calendar dates in RemoveOldCalendarStatements

### DIFF
--- a/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/impl/RemoveOldCalendarStatements.java
+++ b/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/impl/RemoveOldCalendarStatements.java
@@ -16,6 +16,7 @@
 package org.onebusaway.gtfs_transformer.impl;
 
 import org.onebusaway.gtfs.model.ServiceCalendar;
+import org.onebusaway.gtfs.model.ServiceCalendarDate;
 import org.onebusaway.gtfs.services.GtfsMutableRelationalDao;
 import org.onebusaway.gtfs_transformer.services.GtfsTransformStrategy;
 import org.onebusaway.gtfs_transformer.services.TransformContext;
@@ -37,14 +38,26 @@ public class RemoveOldCalendarStatements implements GtfsTransformStrategy {
     public void run(TransformContext transformContext, GtfsMutableRelationalDao gtfsMutableRelationalDao) {
         RemoveEntityLibrary removeEntityLibrary = new RemoveEntityLibrary();
         Set<ServiceCalendar> serviceCalendarsToRemove = new HashSet<ServiceCalendar>();
+        java.util.Date today = new java.util.Date();
+
         for (ServiceCalendar calendar: gtfsMutableRelationalDao.getAllCalendars()) {
-            java.util.Date today = new java.util.Date();
             if (calendar.getEndDate().getAsDate().before(today)){
                 serviceCalendarsToRemove.add(calendar);
             }
         }
         for (ServiceCalendar serviceCalendar : serviceCalendarsToRemove) {
             removeEntityLibrary.removeCalendar(gtfsMutableRelationalDao, serviceCalendar.getServiceId());
+        }
+
+        Set<ServiceCalendarDate> serviceCalendarDatesToRemove = new HashSet<ServiceCalendarDate>();
+        for (ServiceCalendarDate calendarDate : gtfsMutableRelationalDao.getAllCalendarDates()) {
+            if (calendarDate.getDate().getAsDate().before(today)) {
+                serviceCalendarDatesToRemove.add(calendarDate);
+            }
+        }
+        for (ServiceCalendarDate serviceCalendarDate : serviceCalendarDatesToRemove) {
+            // here we can't delete the trips as the serviceid may be active elsewhere
+            removeEntityLibrary.removeServiceCalendarDate(gtfsMutableRelationalDao, serviceCalendarDate);
         }
     }
 }

--- a/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/impl/RemoveOldCalendarStatements.java
+++ b/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/impl/RemoveOldCalendarStatements.java
@@ -20,15 +20,12 @@ import org.onebusaway.gtfs.model.ServiceCalendarDate;
 import org.onebusaway.gtfs.services.GtfsMutableRelationalDao;
 import org.onebusaway.gtfs_transformer.services.GtfsTransformStrategy;
 import org.onebusaway.gtfs_transformer.services.TransformContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.HashSet;
 import java.util.Set;
 
 public class RemoveOldCalendarStatements implements GtfsTransformStrategy {
 
-    private final Logger _log = LoggerFactory.getLogger(RemoveOldCalendarStatements.class);
     @Override
     public String getName() {
         return this.getClass().getSimpleName();
@@ -40,8 +37,8 @@ public class RemoveOldCalendarStatements implements GtfsTransformStrategy {
         Set<ServiceCalendar> serviceCalendarsToRemove = new HashSet<ServiceCalendar>();
         java.util.Date today = new java.util.Date();
 
-        for (ServiceCalendar calendar: gtfsMutableRelationalDao.getAllCalendars()) {
-            if (calendar.getEndDate().getAsDate().before(today)){
+        for (ServiceCalendar calendar : gtfsMutableRelationalDao.getAllCalendars()) {
+            if (calendar.getEndDate().getAsDate().before(today)) {
                 serviceCalendarsToRemove.add(calendar);
             }
         }


### PR DESCRIPTION
**Summary:** 

GTFS Transformer: Some GTFS do not implement calendars. RemoveOldCalendarStatements should also remove calendar dates.

**Expected behavior:** 

Always remove the calendar dates when using this strategy.